### PR TITLE
Updates for mainnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 build/
 *.json
+*.log

--- a/contracts/Libraries/VerusConstants.sol
+++ b/contracts/Libraries/VerusConstants.sol
@@ -11,12 +11,7 @@ pragma abicoder v2;
 
 
 library VerusConstants {
-    address constant public VEth = 0x67460C2f56774eD27EeB8685f29f6CEC0B090B00;
-    address constant public VerusSystemId = 0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d;
-    address constant public VerusCurrencyId = 0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d;
-    address constant public VerusUSDCId = 0xF0A1263056c30E221F0F851C36b767ffF2544f7F;
-    address constant public VerusBridgeAddress = 0xffEce948b8A38bBcC813411D2597f7f8485a0689;
-    address constant public VerusNFTID = 0x9bB2772Aa50ec96ce1305D926B9CC29b7c402bAD;
+
     uint256 constant public transactionFee = 3000000000000000; //0.003 ETH 18 decimals
     uint256 constant public upgradeFee = 1000000000000000; //0.001 ETH 18 decimals WEI  TODO: increase for MAINNET
     uint64 constant public verusTransactionFee = 2000000; //0.02 VRSC 8 decimals
@@ -30,6 +25,7 @@ library VerusConstants {
     uint32 constant IMPORT_TO_SOURCE = 0x200;          
     uint32 constant RESERVE_TO_RESERVE = 0x400; 
     uint32 constant CURRENCY_EXPORT = 0x2000;
+    uint8 constant NFT_POSITION = 0;
 
     uint32 constant INVALID_FLAGS = 0xffffffff - (VALID + CONVERT + RESERVE_TO_RESERVE + IMPORT_TO_SOURCE);
 

--- a/contracts/MMR/VerusProof.sol
+++ b/contracts/MMR/VerusProof.sol
@@ -12,6 +12,17 @@ import "./VerusMMR.sol";
 import "../Storage/StorageMaster.sol";
 
 contract VerusProof is VerusStorage  {
+    
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
 
     using VerusBlake2b for bytes;
     
@@ -241,8 +252,8 @@ contract VerusProof is VerusStorage  {
         }
 
         if (!(hashedTransfers == hashReserveTransfers &&
-                systemSourceID == VerusConstants.VerusSystemId &&
-                destSystemID == VerusConstants.VEth)) {
+                systemSourceID == VERUS &&
+                destSystemID == VETH)) {
 
             revert("CCE information does not checkout");
         }
@@ -403,7 +414,7 @@ contract VerusProof is VerusStorage  {
             temp[i].iaddress = iAddress;
             temp[i].flags = recordedToken.flags;
 
-            if (iAddress == VerusConstants.VEth)
+            if (iAddress == VETH)
             {
                 temp[i].erc20ContractAddress = address(0);
                 temp[i].name = recordedToken.name;

--- a/contracts/Main/Delegator.sol
+++ b/contracts/Main/Delegator.sol
@@ -96,7 +96,7 @@ contract Delegator is VerusStorage, ERC1155Holder, ERC721Holder {
 
     function launchContractTokens(bytes calldata data) external  {
 
-        require(verusToERC20mapping[VerusConstants.VEth].flags == 0 && startOwner == msg.sender);
+        require(contracts.length == 1 && startOwner == msg.sender);
         address logic = contracts[uint(VerusConstants.ContractType.VerusNotaryTools)];
 
         (bool success,) = logic.delegatecall(abi.encodeWithSignature("launchContractTokens(bytes)", data));

--- a/contracts/Main/Delegator.sol
+++ b/contracts/Main/Delegator.sol
@@ -22,11 +22,12 @@ contract Delegator is VerusStorage, ERC1155Holder, ERC721Holder {
         }
         VerusNft t = new VerusNft(); 
 
-        verusToERC20mapping[VerusConstants.VerusNFTID] = 
+        //NOTE: VerusNFT contract is mapped by its unique contract address, as there is no i-address for it.
+        verusToERC20mapping[address(t)] = 
             VerusObjects.mappedToken(address(t), uint8(VerusConstants.MAPPING_VERUS_OWNED + VerusConstants.MAPPING_ERC721_NFT_DEFINITION),
                 0, "VerusNFT", uint256(0));  
 
-        tokenList.push(VerusConstants.VerusNFTID);
+        tokenList.push(address(t));
 
         startOwner = msg.sender;
         for (uint i = 0; i < uint(VerusConstants.NUMBER_OF_CONTRACTS); i++) {
@@ -96,7 +97,7 @@ contract Delegator is VerusStorage, ERC1155Holder, ERC721Holder {
 
     function launchContractTokens(bytes calldata data) external  {
 
-        require(contracts.length == 1 && startOwner == msg.sender);
+        require(tokenList.length == 1 && startOwner == msg.sender);
         address logic = contracts[uint(VerusConstants.ContractType.VerusNotaryTools)];
 
         (bool success,) = logic.delegatecall(abi.encodeWithSignature("launchContractTokens(bytes)", data));

--- a/contracts/VerusBridge/CreateExports.sol
+++ b/contracts/VerusBridge/CreateExports.sol
@@ -13,6 +13,17 @@ import '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
 
 contract CreateExports is VerusStorage {
 
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
+
     function subtractPoolSize(uint64 _amount) private returns (bool) {
 
         if((_amount + VerusConstants.MIN_VRSC_FEE) > remainingLaunchFeeReserves) return false;
@@ -56,7 +67,7 @@ contract CreateExports is VerusStorage {
             require (subtractPoolSize(uint64(transfer.fees)));
         }
 
-        if (transfer.currencyvalue.currency != VerusConstants.VEth) {
+        if (transfer.currencyvalue.currency != VETH) {
             mappedContract = verusToERC20mapping[transfer.currencyvalue.currency];
             ethNftFlag = mappedContract.flags & (VerusConstants.MAPPING_ERC721_NFT_DEFINITION | VerusConstants.MAPPING_ERC1155_NFT_DEFINITION | VerusConstants.MAPPING_ERC1155_ERC_DEFINITION);
         }
@@ -84,13 +95,13 @@ contract CreateExports is VerusStorage {
                 require (nft.getApproved(mappedContract.tokenID) == address(this), "NFT not approved");
                 nft.safeTransferFrom(msg.sender, address(this), mappedContract.tokenID, "");
 
-                if (transfer.currencyvalue.currency == VerusConstants.VerusNFTID) {
+                if (transfer.currencyvalue.currency == verusToERC20mapping[tokenList[VerusConstants.NFT_POSITION]].erc20ContractAddress) {
                     nft.burn(mappedContract.tokenID);
                 }
             } else {
                 revert();
             }
-         } else if (transfer.currencyvalue.currency != VerusConstants.VEth) {
+         } else if (transfer.currencyvalue.currency != VETH) {
 
             Token token = Token(mappedContract.erc20ContractAddress); 
             //Check user has allowed the verusBridgeStorage contract to spend on their behalf
@@ -107,7 +118,7 @@ contract CreateExports is VerusStorage {
             //total amount kept as uint256 until export to verus
             exportERC20Tokens(tokenAmount, token, mappedContract.flags & VerusConstants.MAPPING_VERUS_OWNED == VerusConstants.MAPPING_VERUS_OWNED);
             
-        } else if(transfer.currencyvalue.currency != VerusConstants.VEth) {
+        } else if(transfer.currencyvalue.currency != VETH) {
             revert ("unknown type");
         }
         _createExports(transfer, false);

--- a/contracts/VerusBridge/ExportManager.sol
+++ b/contracts/VerusBridge/ExportManager.sol
@@ -11,6 +11,17 @@ import "../Storage/StorageMaster.sol";
 
 contract ExportManager is VerusStorage  {
 
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
+
     uint8 constant UINT160_SIZE = 20; 
     uint8 constant FEE_OFFSET = 20 + 20 + 20 + 8; // 3 x 20bytes address + 64bit uint // 3 x 20bytes address + 64bit uint
     // Aux dest can only be one vector, of one vector which is a CTransferDestiantion of an R address.
@@ -54,7 +65,7 @@ contract ExportManager is VerusStorage  {
 
         if (!bridgeConverterActive) {
 
-            require (transfer.feecurrencyid == VerusConstants.VerusCurrencyId, "feecurrencyid != vrsc");
+            require (transfer.feecurrencyid == VERUS, "feecurrencyid != vrsc");
             
             if (transfer.destination.destinationtype == (VerusConstants.DEST_ETH + VerusConstants.FLAG_DEST_GATEWAY + VerusConstants.FLAG_DEST_AUX) ||
                 transfer.flags != VerusConstants.VALID)
@@ -66,7 +77,7 @@ contract ExportManager is VerusStorage  {
             
             transferFee = int64(transfer.fees);
 
-            require(transfer.feecurrencyid == VerusConstants.VEth, "Fee Currency not vETH"); //TODO:Accept more fee currencies
+            require(transfer.feecurrencyid == VETH, "Fee Currency not vETH"); //TODO:Accept more fee currencies
 
             if (transfer.destination.destinationtype == (VerusConstants.FLAG_DEST_GATEWAY + VerusConstants.DEST_ETH + VerusConstants.FLAG_DEST_AUX)) {
 
@@ -93,7 +104,7 @@ contract ExportManager is VerusStorage  {
                 
                 require (auxDestPrefix == VerusConstants.AUX_DEST_PREFIX, "auxDestPrefix Incorrect");
                 require (auxDestAddress != address(0), "auxDestAddress must not be empty");
-                require (gatewayID == VerusConstants.VEth, "GatewayID not VETH");
+                require (gatewayID == VETH, "GatewayID not VETH");
                 require (gatewayCode == address(0), "GatewayCODE must be empty");
 
                 bounceBackFee = reverse(uint64(bounceBackFee));
@@ -120,12 +131,12 @@ contract ExportManager is VerusStorage  {
             {
                 revert ("ETH Fees to Low");
             }            
-            else if (transfer.currencyvalue.currency == VerusConstants.VEth && 
+            else if (transfer.currencyvalue.currency == VETH && 
                 msg.value < convertFromVerusNumber(uint256(amount + uint64(transferFee)), 18))
             {
                 revert ("ETH sent < (amount + fees)");
             } 
-            else if (transfer.currencyvalue.currency != VerusConstants.VEth &&
+            else if (transfer.currencyvalue.currency != VETH &&
                     msg.value < convertFromVerusNumber(uint64(transferFee), 18))
             {
                 revert ("ETH fee sent < fees for token");
@@ -139,12 +150,12 @@ contract ExportManager is VerusStorage  {
             {
                 revert ("Invalid VRSC fee");
             }
-            else if (transfer.currencyvalue.currency == VerusConstants.VEth &&
+            else if (transfer.currencyvalue.currency == VETH &&
                      (convertFromVerusNumber(amount, 18) + requiredFees) != msg.value)
             {
                 revert ("ETH Fee to low");
             }
-            else if(transfer.currencyvalue.currency != VerusConstants.VEth && requiredFees != msg.value)
+            else if(transfer.currencyvalue.currency != VETH && requiredFees != msg.value)
             {
                 revert ("ETH Fee to low (token)");
             }
@@ -175,7 +186,7 @@ contract ExportManager is VerusStorage  {
 
         if (transfer.flags == VerusConstants.VALID && transfer.secondreserveid == address(0))
         {
-            require (transfer.destcurrencyid == (bridgeConverterActive ? VerusConstants.VerusBridgeAddress : VerusConstants.VerusCurrencyId),  
+            require (transfer.destcurrencyid == (bridgeConverterActive ? BRIDGE : VERUS),  
                         "Invalid desttype");
         }
         else if (transfer.flags == (VerusConstants.VALID + VerusConstants.CONVERT + VerusConstants.RESERVE_TO_RESERVE))

--- a/contracts/VerusBridge/SubmitImports.sol
+++ b/contracts/VerusBridge/SubmitImports.sol
@@ -12,6 +12,17 @@ import "../Storage/StorageMaster.sol";
 
 contract SubmitImports is VerusStorage {
 
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
+
     uint32 constant ELVCHOBJ_TXID_OFFSET = 32;
     uint32 constant ELVCHOBJ_NVINS_OFFSET = 45;
     uint32 constant FORKS_NOTARY_INDEX = 106;  // this is txid + stateroot + blockhash + NOTARIZER_INDEX_AND_FLAGS_OFFSET 
@@ -23,7 +34,7 @@ contract SubmitImports is VerusStorage {
       
         LPtransfer.version = 1;
         LPtransfer.destination.destinationtype = destinationType;
-        LPtransfer.destcurrencyid = VerusConstants.VerusBridgeAddress;
+        LPtransfer.destcurrencyid = BRIDGE;
         LPtransfer.destsystemid = address(0);
         LPtransfer.secondreserveid = address(0);
 
@@ -37,15 +48,15 @@ contract SubmitImports is VerusStorage {
         }
         
         if (value == 0) {
-            LPtransfer.currencyvalue.currency = VerusConstants.VerusCurrencyId;
+            LPtransfer.currencyvalue.currency = VERUS;
             LPtransfer.fees = VerusConstants.verusTransactionFee; 
-            LPtransfer.feecurrencyid = VerusConstants.VerusCurrencyId;
+            LPtransfer.feecurrencyid = VERUS; 
             LPtransfer.currencyvalue.amount = uint64(remainingLaunchFeeReserves - VerusConstants.verusTransactionFee);
             forceNewCCE = true;
         } else {
-            LPtransfer.currencyvalue.currency = VerusConstants.VEth;
+            LPtransfer.currencyvalue.currency = VETH;
             LPtransfer.fees = VerusConstants.verusvETHTransactionFee; 
-            LPtransfer.feecurrencyid = VerusConstants.VEth;
+            LPtransfer.feecurrencyid = VETH;
             LPtransfer.currencyvalue.amount = uint64(value - VerusConstants.verusvETHTransactionFee);  
             forceNewCCE = false;
         } 
@@ -282,6 +293,7 @@ contract SubmitImports is VerusStorage {
     {
         uint64 refundAmount;
         refundAmount = uint64(refunds[bytes32(uint256(verusAddress))]);
+        require(bridgeConverterActive, "Bridge converter not active");
 
         if (refundAmount > 0)
         {
@@ -296,6 +308,7 @@ contract SubmitImports is VerusStorage {
 
     function sendfees(bytes32 publicKeyX, bytes32 publicKeyY) public 
     {
+        require(bridgeConverterActive, "Bridge converter not active");
         uint8 leadingByte;
 
         leadingByte = (uint256(publicKeyY) & 1) == 1 ? 0x03 : 0x02;

--- a/contracts/VerusBridge/TokenManager.sol
+++ b/contracts/VerusBridge/TokenManager.sol
@@ -17,6 +17,17 @@ import "../Storage/StorageMaster.sol";
 
 contract TokenManager is VerusStorage {
 
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
+
     function getName(address cont) private view returns (string memory)
     {
         // Wrapper functions to enable try catch to work
@@ -55,7 +66,7 @@ contract TokenManager is VerusStorage {
 
             outputName = string(abi.encodePacked(outputName, _tx[j].name));
 
-            if (_tx[j].parent != VerusConstants.VerusSystemId)
+            if (_tx[j].parent != VERUS)
             {
                 outputName = string(abi.encodePacked(outputName, ".", verusToERC20mapping[_tx[j].parent].name));
             }
@@ -83,7 +94,7 @@ contract TokenManager is VerusStorage {
             }
             else if (flags & VerusConstants.MAPPING_ERC721_NFT_DEFINITION == VerusConstants.MAPPING_ERC721_NFT_DEFINITION)
             {
-                ERCContract = verusToERC20mapping[VerusConstants.VerusNFTID].erc20ContractAddress;
+                ERCContract = verusToERC20mapping[tokenList[VerusConstants.NFT_POSITION]].erc20ContractAddress;
                 tokenID = uint256(uint160(_iaddress)); //tokenID is the i address
             }
         }
@@ -129,7 +140,7 @@ contract TokenManager is VerusStorage {
             destinationAddress  = address(uint160(trans[i].destinationAndFlags));
             sendAmount = uint64(trans[i].currencyAndAmount >> VerusConstants.UINT160_BITS_SIZE);
             
-            if (address(uint160(trans[i].currencyAndAmount)) == VerusConstants.VEth) 
+            if (address(uint160(trans[i].currencyAndAmount)) == VETH) 
             {
                 if (!payable(destinationAddress).send(sendAmount * VerusConstants.SATS_TO_WEI_STD)) {
                     // Note: Refund address is a CTransferdestination and Amount is in VerusSATS, so store as that.

--- a/contracts/VerusBridge/UpgradeManager.sol
+++ b/contracts/VerusBridge/UpgradeManager.sol
@@ -26,10 +26,7 @@ contract UpgradeManager is VerusStorage {
 
     function upgradeContracts(bytes calldata data) external payable returns (uint8) {
 
-       // if (contracts.length == 11) {
-       //     contracts.push(0x70C9C24ce7986F71765Bcc8FF504D3E0Fe784225);
-       //     return COMPLETE;
-       // } TODO: only enabled for testnetupgrade
+
 
         require(msg.value > VerusConstants.upgradeFee);
 

--- a/contracts/VerusBridge/VerusCrossChainExport.sol
+++ b/contracts/VerusBridge/VerusCrossChainExport.sol
@@ -10,6 +10,17 @@ import "../VerusBridge/VerusSerializer.sol";
 
 contract VerusCrossChainExport {
 
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
+
     VerusObjects.CCurrencyValueMap[] currencies;
     VerusObjects.CCurrencyValueMap[] fees;
 
@@ -65,14 +76,14 @@ contract VerusCrossChainExport {
         workingCCE.flags = 2;
         workingCCE.sourceheightstart = startheight;
         workingCCE.sourceheightend = endheight;
-        workingCCE.sourcesystemid = VerusConstants.VEth;
+        workingCCE.sourcesystemid = VETH;
         workingCCE.hashtransfers = hashedTransfers;
-        workingCCE.destinationsystemid = VerusConstants.VerusSystemId;
+        workingCCE.destinationsystemid = VERUS;
 
         if (bridgeReady) { 
-            workingCCE.destinationcurrencyid = VerusConstants.VerusBridgeAddress;  //NOTE:transfers are bundled by type
+            workingCCE.destinationcurrencyid = BRIDGE;  //NOTE:transfers are bundled by type
         } else {
-            workingCCE.destinationcurrencyid = VerusConstants.VerusCurrencyId; 
+            workingCCE.destinationcurrencyid = VERUS; 
         }
 
         workingCCE.numinputs = uint32(transfers.length);

--- a/contracts/VerusBridge/VerusSerializer.sol
+++ b/contracts/VerusBridge/VerusSerializer.sol
@@ -329,7 +329,7 @@ contract VerusSerializer {
         
             returnCurrency.flags |= uint8(VerusConstants.MAPPING_ERC721_NFT_DEFINITION);
             returnCurrency.flags |= uint8(VerusConstants.MAPPING_VERUS_OWNED);
-            nativeCurrencyID = VerusConstants.VerusNFTID;
+            nativeCurrencyID = address(0); //The Verus NFT contract is not known by this contract so it will be set when the NFT is minted.
         }
         else { // Verus owned ERC20, ERC20 contract not known yet.
         

--- a/contracts/VerusNotarizer/NotarizationSerializer.sol
+++ b/contracts/VerusNotarizer/NotarizationSerializer.sol
@@ -11,6 +11,17 @@ import "../Storage/StorageMaster.sol";
 
 contract NotarizationSerializer is VerusStorage {
 
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
+
     uint8 constant CURRENCY_LENGTH = 20;
     uint8 constant BYTES32_LENGTH = 32;
     uint8 constant TWO2BYTES32_LENGTH = 64;
@@ -131,7 +142,7 @@ contract NotarizationSerializer is VerusStorage {
         }
     }
 
-    function deserializeCoinbaseCurrencyState(bytes memory notarization, uint32 nextOffset) private pure returns (uint16, uint32)
+    function deserializeCoinbaseCurrencyState(bytes memory notarization, uint32 nextOffset) private view returns (uint16, uint32)
     {
         address currencyid;
         uint16 bridgeLaunched;
@@ -145,7 +156,7 @@ contract NotarizationSerializer is VerusStorage {
             currencyid := mload(add(notarization, nextOffset))      // currencyid 
         }
         flags = (flags >> 8) | (flags << 8);
-        if ((currencyid == VerusConstants.VerusBridgeAddress) && flags & (FLAG_FRACTIONAL + FLAG_REFUNDING + FLAG_LAUNCHCONFIRMED + FLAG_LAUNCHCOMPLETEMARKER) == 
+        if ((currencyid == BRIDGE) && flags & (FLAG_FRACTIONAL + FLAG_REFUNDING + FLAG_LAUNCHCONFIRMED + FLAG_LAUNCHCOMPLETEMARKER) == 
             (FLAG_FRACTIONAL + FLAG_LAUNCHCONFIRMED + FLAG_LAUNCHCOMPLETEMARKER)) 
         {
             bridgeLaunched = 1;
@@ -174,7 +185,7 @@ contract NotarizationSerializer is VerusStorage {
         return (bridgeLaunched, nextOffset);
     }
 
-    function deserializeProofRoots (bytes memory notarization, uint32 size, uint32 nextOffset) private pure returns (bytes32 stateRoot, bytes32 blockHash, uint32 height)
+    function deserializeProofRoots (bytes memory notarization, uint32 size, uint32 nextOffset) private view returns (bytes32 stateRoot, bytes32 blockHash, uint32 height)
     {
         for (uint i = 0; i < size; i++)
         {
@@ -199,7 +210,7 @@ contract NotarizationSerializer is VerusStorage {
                 nextOffset := add(nextOffset, BYTES32_LENGTH) // move to power
             }
             
-            if(systemID == VerusConstants.VerusCurrencyId)
+            if(systemID == VERUS)
             {
                 stateRoot = tempStateRoot;
                 blockHash = tempBlockHash;

--- a/contracts/VerusNotarizer/VerusNotarizer.sol
+++ b/contracts/VerusNotarizer/VerusNotarizer.sol
@@ -12,6 +12,17 @@ import "../VerusBridge/UpgradeManager.sol";
 import "../Storage/StorageMaster.sol";
 
 contract VerusNotarizer is VerusStorage {
+
+    address immutable VETH;
+    address immutable BRIDGE;
+    address immutable VERUS;
+
+    constructor(address vETH, address Bridge, address Verus){
+
+        VETH = vETH;
+        BRIDGE = Bridge;
+        VERUS = Verus;
+    }
         
     uint8 constant FLAG_FRACTIONAL = 1;
     uint8 constant FLAG_REFUNDING = 4;
@@ -73,7 +84,7 @@ contract VerusNotarizer is VerusStorage {
                     vdxfcode,
                     uint8(1),
                     txidHash,
-                    VerusConstants.VerusSystemId,
+                    VERUS,
                     serializeUint32(blockheights[i]),
                     notaryAddresses[i], 
                     keccakNotarizationHash));

--- a/migrations/setup.js
+++ b/migrations/setup.js
@@ -4,8 +4,18 @@ const MAPPING_PARTOF_BRIDGEVETH = 4;
 const MAPPING_ISBRIDGE_CURRENCY = 8;
 const MAPPING_ERC20_DEFINITION = 32;
 
-// These are the notaries iaddresses in hex form.
-exports.verusNotariserIDS = ["0x429c5f2039f259c02885972852438731f21fc949",
+// These are the mainnet notaries iaddresses in hex form.
+const verusMainnetNotariserIDS = [];
+
+// These are the equivelent ETH mainnet addresses of the notaries Spending R addresses
+const verusMainnetNotariserSigner = [];
+
+// These are the equivelent ETH mainnet addresses of the notaries Recovery R addresses
+const verusMainnetNotariserRecovery = [];
+
+// These are the notaries goerli iaddresses in hex form.
+const verusGoerliNotariserIDS = [
+    "0x429c5f2039f259c02885972852438731f21fc949",
     "0xcc86752da0c3629b7478c2b542d8b5055efee861",
     "0x9ea954a6086ba4693af454be3bfa34c9af27b6b4",
     "0xc6d8a087e1429b3676913435fb21e42569005ebc",
@@ -25,8 +35,9 @@ exports.verusNotariserIDS = ["0x429c5f2039f259c02885972852438731f21fc949",
     "0x6fa063cf74dd44d72cb7021f2c5e51c0a34bfd9e",
     "0x39c893ffa61a12e899f8f255b5e09067922df277"];
 
-// These are the equivelent ETH addresses of the notaries Spending R addresses
-exports.verusNotariserSigner = ["0x75201d47A549C39531aD22Fda6A0B2b99B5b61e1",
+// These are the equivelent ETH goerli addresses of the notaries Spending R addresses
+const verusGoerliNotariserSigner = [
+    "0x75201d47A549C39531aD22Fda6A0B2b99B5b61e1",
     "0x50af1B0fda9690C5B50fC6dc1036eC07d4C190e7",
     "0x696921eD978F93558C327d4727e49EE506Da6381",
     "0x9961E69D5B8c229e033143141A4611346C5BCEbb",
@@ -46,8 +57,9 @@ exports.verusNotariserSigner = ["0x75201d47A549C39531aD22Fda6A0B2b99B5b61e1",
     "0xC994C8eDBfa60db9E90665925686CD53cc65Bb64",
     "0x92352245278B8c973209a83B509c19Ef921925B9"];
 
-// These are the equivelent ETH addresses of the notaries Recovery R addresses
-exports.verusNotariserRecovery = ["0x75201d47A549C39531aD22Fda6A0B2b99B5b61e1",
+// These are the equivelent ETH goerli addresses of the notaries Recovery R addresses
+const verusGoerliNotariserRecovery = [
+    "0x75201d47A549C39531aD22Fda6A0B2b99B5b61e1",
     "0x50af1B0fda9690C5B50fC6dc1036eC07d4C190e7",
     "0x696921eD978F93558C327d4727e49EE506Da6381",
     "0x9961E69D5B8c229e033143141A4611346C5BCEbb",
@@ -66,58 +78,109 @@ exports.verusNotariserRecovery = ["0x75201d47A549C39531aD22Fda6A0B2b99B5b61e1",
     "0x64745BC0a92E11c7b0809F042EBAdC92b2b0d014",
     "0xC994C8eDBfa60db9E90665925686CD53cc65Bb64",
     "0x92352245278B8c973209a83B509c19Ef921925B9"];
+
+// These are the development notaries iaddresses in hex form.
+const TestVerusNotariserIDS = [
+    "0xb26820ee0c9b1276aac834cf457026a575dfce84", 
+    "0x51f9f5f053ce16cb7ca070f5c68a1cb0616ba624", 
+    "0x65374d6a8b853a5f61070ad7d774ee54621f9638"];
+
+// These are the equivelent ETH development addresses of the notaries Spending R addresses
+const TestVerusNotariserSigner = [
+    "0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41", 
+    "0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41", 
+    "0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41"];
+
+// These are the equivelent ETH development addresses of the notaries Recovery R addresses
+const TestVerusNotariserRecovery = [
+    "0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41", 
+    "0xD3258AD271066B7a780C68e527A6ee69ecA15b7F", 
+    "0x68f56bA248E23b7d5DE4Def67592a1366431d345"];
+
+const getNotarizerIDS = (network) => {
+
+    if (network == "development"){
+        return [TestVerusNotariserIDS, TestVerusNotariserSigner, TestVerusNotariserRecovery];
+    } else if (network == "goerli"){
+        return [verusGoerliNotariserIDS, verusGoerliNotariserSigner, verusGoerliNotariserRecovery];
+    } else if (network == "mainnet"){
+        return [verusMainnetNotariserIDS, verusMainnetNotariserSigner, verusMainnetNotariserRecovery];
+    }
+}
+
+// Verus ID's in uint160 format
+const id = {  
+    mainnet: {
+        VETH: "0x454CB83913D688795E237837d30258d11ea7c752",
+        VRSC: "0x1Af5b8015C64d39Ab44C60EAd8317f9F5a9B6C4C",
+        BRIDGE: "0x0200EbbD26467B866120D84A0d37c82CdE0acAEB",
+        DAI: "0x8b72F1c2D326d376aDd46698E385Cf624f0CA1dA",
+        DAIERC20: "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+    },
+    testnet: {
+        VETH: "0x67460C2f56774eD27EeB8685f29f6CEC0B090B00",
+        VRSC: "0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d",
+        BRIDGE: "0xffEce948b8A38bBcC813411D2597f7f8485a0689",
+        DAI: "0xcce5d18f305474f1e0e0ec1c507d8c85e7315fdf",
+        DAIERC20: "0xB897f2448054bc5b133268A53090e110D101FFf0"
+    },
+    emptyuint160: "0x0000000000000000000000000000000000000000",
+    emptyuint256: "0x0000000000000000000000000000000000000000000000000000000000000000"
+}
+
+const returnConstructorCurrencies = (isTestnet = false) => {
+
+    return [
+        isTestnet ? id.testnet.VETH : id.mainnet.VETH,
+        isTestnet ? id.testnet.BRIDGE : id.mainnet.BRIDGE,
+        isTestnet ? id.testnet.VRSC : id.mainnet.VRSC
+    ]
+}
 
 // currencies that are defined are in this format:
 // iaddress in hex, ERC20 contract, parent, token options, name, ticker, NFTtokenID.
+const returnSetupCurrencies = (isTestnet = false) => {
 
-const vrsctest = ["0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d", 
-    "0x0000000000000000000000000000000000000000", 
-    "0x0000000000000000000000000000000000000000", 
-    MAPPING_VERUS_OWNED + MAPPING_PARTOF_BRIDGEVETH + MAPPING_ERC20_DEFINITION, 
-    "VRSCTEST",
-    "VRSC",
-    "0x0000000000000000000000000000000000000000000000000000000000000000"];
-	
-const bridgeeth = ["0xffEce948b8A38bBcC813411D2597f7f8485a0689", 
-    "0x0000000000000000000000000000000000000000", 
-    "0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d", 
-    MAPPING_VERUS_OWNED + MAPPING_ISBRIDGE_CURRENCY + MAPPING_ERC20_DEFINITION, 
-    "bridge.vETH", 
-    "BETH",
-    "0x0000000000000000000000000000000000000000000000000000000000000000"];
-	
-const usdc = ["0xf0a1263056c30e221f0f851c36b767fff2544f7f", 
-    "0x98339D8C260052B7ad81c28c16C0b98420f2B46a", 
-    "0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d", 
-    MAPPING_ETHEREUM_OWNED + MAPPING_PARTOF_BRIDGEVETH + MAPPING_ERC20_DEFINITION, 
-    "USDC (Testnet)", 
-    "USDC",
-    "0x0000000000000000000000000000000000000000000000000000000000000000"];
-	
-const veth = ["0x67460C2f56774eD27EeB8685f29f6CEC0B090B00", 
-    "0x06012c8cf97bead5deae237070f9587f8e7a266d", 
-    "0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d",
-    MAPPING_ETHEREUM_OWNED + MAPPING_PARTOF_BRIDGEVETH + MAPPING_ERC20_DEFINITION, 
-    "ETH (Testnet)", 
-    "ETH",
-    "0x0000000000000000000000000000000000000000000000000000000000000000"];
+    const vrsc = [
+        isTestnet ? id.testnet.VRSC : id.mainnet.VRSC,
+        id.emptyuint160, 
+        id.emptyuint160, 
+        MAPPING_VERUS_OWNED + MAPPING_PARTOF_BRIDGEVETH + MAPPING_ERC20_DEFINITION, 
+        isTestnet ? "VRSCTEST" : "VRSC",
+        "VRSC",
+        id.emptyuint256];
+        
+    const bridgeeth = [
+        isTestnet ? id.testnet.BRIDGE : id.mainnet.BRIDGE,
+        id.emptyuint160, 
+        isTestnet ? id.testnet.VRSC : id.mainnet.VRSC,
+        MAPPING_VERUS_OWNED + MAPPING_ISBRIDGE_CURRENCY + MAPPING_ERC20_DEFINITION, 
+        "Bridge.vETH", 
+        "BETH",
+        id.emptyuint256];
+        
+    const veth = [
+        isTestnet ? id.testnet.VETH : id.mainnet.VETH,
+        id.emptyuint160,
+        isTestnet ? id.testnet.VRSC : id.mainnet.VRSC,
+        MAPPING_ETHEREUM_OWNED + MAPPING_PARTOF_BRIDGEVETH + MAPPING_ERC20_DEFINITION, 
+        isTestnet ? "ETH (Testnet)" : "ETH", 
+        "ETH",
+        id.emptyuint256];
 
-const dai = ["0xcce5d18f305474f1e0e0ec1c507d8c85e7315fdf", 
-    "0xB897f2448054bc5b133268A53090e110D101FFf0", 
-    "0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d", 
-    MAPPING_ETHEREUM_OWNED + MAPPING_PARTOF_BRIDGEVETH + MAPPING_ERC20_DEFINITION, 
-    "DAI (Testnet)", 
-    "DAI",
-    "0x0000000000000000000000000000000000000000000000000000000000000000"];
+    const dai = [
+        isTestnet ? id.testnet.DAI : id.mainnet.DAI,
+        isTestnet ? id.testnet.DAIERC20 : id.mainnet.DAIERC20,
+        isTestnet ? id.testnet.VRSC : id.mainnet.VRSC, 
+        MAPPING_ETHEREUM_OWNED + MAPPING_PARTOF_BRIDGEVETH + MAPPING_ERC20_DEFINITION, 
+        isTestnet ? "DAI (Testnet)" : "DAI", 
+        "DAI",
+        id.emptyuint256];
 
-// Setup the tokens to be launched with the contract here.  Important this must match the vETH definitions.
+    return [vrsc, bridgeeth, veth, dai];
+}
 
-exports.arrayofcurrencies = [vrsctest, bridgeeth, veth, dai]
-
-exports.TestVerusNotariserIDS = ["0xb26820ee0c9b1276aac834cf457026a575dfce84", "0x51f9f5f053ce16cb7ca070f5c68a1cb0616ba624", "0x65374d6a8b853a5f61070ad7d774ee54621f9638"];
-
-// These are the equivelent ETH addresses of the notaries Spending R addresses
-exports.TestVerusNotariserSigner = ["0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41", "0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41", "0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41"];
-
-// These are the equivelent ETH addresses of the notaries Recovery R addresses
-exports.TestVerusNotariserRecovery = ["0xD010dEBcBf4183188B00cafd8902e34a2C1E9f41", "0xD3258AD271066B7a780C68e527A6ee69ecA15b7F", "0x68f56bA248E23b7d5DE4Def67592a1366431d345"];
+exports.id = id;
+exports.getNotarizerIDS = getNotarizerIDS;
+exports.arrayofcurrencies = returnSetupCurrencies;
+exports.returnConstructorCurrencies = returnConstructorCurrencies;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -67,6 +67,15 @@ module.exports = {
             networkCheckTimeout: 10000,
         },
 
+        mainnet: {
+            provider: () => { return new HDWalletProvider(privateKeys, 'wss://mainnet.infura.io/ws/v3/.....') },
+            network_id: 1, // 1 = ethereum mainnet
+            confirmations: 0, // # of confs to wait between deployments. (default: 0)
+            timeoutBlocks: 50, // # of blocks before a deployment times out  (minimum/default: 50)
+            skipDryRun: false, // Skip dry run before migrations? (default: false for public nets )
+            networkCheckTimeout: 10000,
+        },
+
         // Useful for private networks
         // private: {
         // provider: () => new HDWalletProvider(mnemonic, `https://network.io`),


### PR DESCRIPTION
Constants updated to mainnet constants for DAI, VRSC and Bridge.Veth - To be checked 
```js 
// migrations/setup.js
const id = {  
    mainnet: {
        VETH: "0x454CB83913D688795E237837d30258d11ea7c752",
        VRSC: "0x1Af5b8015C64d39Ab44C60EAd8317f9F5a9B6C4C",
        BRIDGE: "0x0200EbbD26467B866120D84A0d37c82CdE0acAEB",
        DAI: "0x8b72F1c2D326d376aDd46698E385Cf624f0CA1dA",
        DAIERC20: "0x6B175474E89094C44Da98b954EedeAC495271d0F"
    },
    testnet: {
        VETH: "0x67460C2f56774eD27EeB8685f29f6CEC0B090B00",
        VRSC: "0xA6ef9ea235635E328124Ff3429dB9F9E91b64e2d",
        BRIDGE: "0xffEce948b8A38bBcC813411D2597f7f8485a0689",
        DAI: "0xcce5d18f305474f1e0e0ec1c507d8c85e7315fdf",
        DAIERC20: "0xB897f2448054bc5b133268A53090e110D101FFf0"
    },
    emptyuint160: "0x0000000000000000000000000000000000000000",
    emptyuint256: "0x0000000000000000000000000000000000000000000000000000000000000000"
}```

All  i-address constants not hard coded and settable on deployment, and DAI ERC20 Address for mainnet and testnet.