### PR TITLE
Updates for NFT accounting

### DIFF
--- a/contracts/VerusBridge/CreateExports.sol
+++ b/contracts/VerusBridge/CreateExports.sol
@@ -81,36 +81,43 @@ contract CreateExports is VerusStorage {
             iaddressMapping = verusToERC20mapping[transfer.currencyvalue.currency];
             ethNftFlag = iaddressMapping.flags & (VerusConstants.MAPPING_ERC721_NFT_DEFINITION | VerusConstants.MAPPING_ERC1155_NFT_DEFINITION | VerusConstants.MAPPING_ERC1155_ERC_DEFINITION);
         }
+  
+        uint balance;
 
-        if (ethNftFlag != 0) { //handle a NFT Import
-            uint balance;
-            if (ethNftFlag == VerusConstants.MAPPING_ERC1155_NFT_DEFINITION || ethNftFlag == VerusConstants.MAPPING_ERC1155_ERC_DEFINITION) {
-                IERC1155 nft = IERC1155(iaddressMapping.erc20ContractAddress);
+        if (ethNftFlag & (VerusConstants.MAPPING_ERC1155_NFT_DEFINITION | VerusConstants.MAPPING_ERC1155_ERC_DEFINITION) != 0) {
+            IERC1155 nft = IERC1155(iaddressMapping.erc20ContractAddress);
 
-                // TokenIndex is used for ERC1155's only for the amount of tokens held by the bridge
+            // TokenIndex is used for the amount of tokens held by the bridge (for erc1155's and ERC721's)
+            if (ethNftFlag == VerusConstants.MAPPING_ERC1155_ERC_DEFINITION) {
                 require((transfer.currencyvalue.amount + iaddressMapping.tokenIndex) < VerusConstants.MAX_VERUS_TRANSFER);
-                verusToERC20mapping[transfer.currencyvalue.currency].tokenIndex += transfer.currencyvalue.amount;
-
-                require (nft.isApprovedForAll(msg.sender, address(this)), "NFT not approved");
-                balance = nft.balanceOf(address(this), iaddressMapping.tokenID);
-                nft.safeTransferFrom(msg.sender, address(this), iaddressMapping.tokenID, transfer.currencyvalue.amount, ""); 
-                require(nft.balanceOf(address(this), iaddressMapping.tokenID) == balance + transfer.currencyvalue.amount, "1155NFTfail");
-
-            } else if (ethNftFlag == VerusConstants.MAPPING_ERC721_NFT_DEFINITION){
-                VerusNft nft = VerusNft(iaddressMapping.erc20ContractAddress);
-                require (nft.getApproved(iaddressMapping.tokenID) == address(this), "NFT not approved");
-                
-                balance = nft.balanceOf(address(this));
-                nft.safeTransferFrom(msg.sender, address(this), iaddressMapping.tokenID, "");
-                require(nft.balanceOf(address(this)) == balance + 1, "721NFTfail");
-
-                if (iaddressMapping.erc20ContractAddress == verusToERC20mapping[tokenList[VerusConstants.NFT_POSITION]].erc20ContractAddress) {
-                    nft.burn(iaddressMapping.tokenID);
-                }
             } else {
-                revert();
+                require(iaddressMapping.tokenIndex == 0);
             }
-         } else if (transfer.currencyvalue.currency != VETH) {
+
+            verusToERC20mapping[transfer.currencyvalue.currency].tokenIndex += transfer.currencyvalue.amount;
+
+            require (nft.isApprovedForAll(msg.sender, address(this)), "NFT not approved");
+            balance = nft.balanceOf(address(this), iaddressMapping.tokenID);
+            nft.safeTransferFrom(msg.sender, address(this), iaddressMapping.tokenID, transfer.currencyvalue.amount, ""); 
+            require(nft.balanceOf(address(this), iaddressMapping.tokenID) == balance + transfer.currencyvalue.amount);
+
+        } else if (ethNftFlag == VerusConstants.MAPPING_ERC721_NFT_DEFINITION){
+
+            VerusNft nft = VerusNft(iaddressMapping.erc20ContractAddress);
+            require (nft.getApproved(iaddressMapping.tokenID) == address(this), "NFT not approved");
+
+            require(iaddressMapping.tokenIndex == 0);
+            balance = nft.balanceOf(address(this));
+            nft.safeTransferFrom(msg.sender, address(this), iaddressMapping.tokenID, "");
+            require(nft.balanceOf(address(this)) == balance + 1);
+
+            if (iaddressMapping.erc20ContractAddress == verusToERC20mapping[tokenList[VerusConstants.NFT_POSITION]].erc20ContractAddress) {
+                nft.burn(iaddressMapping.tokenID);
+            } else {
+                //Only non-verus ERC721 NFTs need their accounting to be checked as they could be non standard.
+                verusToERC20mapping[transfer.currencyvalue.currency].tokenIndex += transfer.currencyvalue.amount;
+            }
+        } else if (transfer.currencyvalue.currency != VETH) {
 
             Token token = Token(iaddressMapping.erc20ContractAddress); 
             //Check user has allowed the verusBridgeStorage contract to spend on their behalf
@@ -119,7 +126,7 @@ contract CreateExports is VerusStorage {
             require( allowedTokens >= tokenAmount);
 
             if (iaddressMapping.flags & VerusConstants.MAPPING_ETHEREUM_OWNED == VerusConstants.MAPPING_ETHEREUM_OWNED) {
-                // TokenID is used for ERC20's only for the amount of tokens held by the bridge
+                // TokenID is used for the amount of tokens held by the bridge  ERC20's
 
                 require((transfer.currencyvalue.amount + iaddressMapping.tokenID) < VerusConstants.MAX_VERUS_TRANSFER);
                     verusToERC20mapping[transfer.currencyvalue.currency].tokenID += transfer.currencyvalue.amount;

--- a/contracts/VerusBridge/TokenManager.sol
+++ b/contracts/VerusBridge/TokenManager.sol
@@ -247,7 +247,7 @@ contract TokenManager is VerusStorage {
                 refundsData = abi.encodePacked(refundsData, refundAddresses[i], sendAmount, currencyiAddress);
             } else if (result == SEND_SUCCESS) {
                 verusToERC20mapping[currencyiAddress].tokenID -= sendAmount;
-            } else if (result == SEND_SUCCESS_ERC1155) {
+            } else if (result == SEND_SUCCESS_ERC1155 || result == SEND_SUCCESS_ERC721) {
                 // TokenIndex used for ERC1155 Acounting so decrement holdings if successful
                 verusToERC20mapping[currencyiAddress].tokenIndex -= sendAmount;
             }


### PR DESCRIPTION
- ERC721 and ERC1155's that are mapped to a type ETHNFT in verus can only be sent 1 token from ethereum. checks to make sure a non standard ERC token cannot break the rules
- 